### PR TITLE
Fix #3: Install systemd-sysv to create /sbin/init link.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV pip_packages "ansible cryptography"
 # Install dependencies.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       sudo systemd \
+       sudo systemd systemd-sysv \
        build-essential wget libffi-dev libssl-dev \
        python-pip python-dev python-setuptools python-wheel \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Without /sbin/init being a link to systemd, testinfra assumes SysV.

Fixes #3 