### PR TITLE
Add /bin/kill to the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV pip_packages "ansible cryptography"
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        sudo systemd systemd-sysv \
-       build-essential wget libffi-dev libssl-dev \
+       build-essential wget libffi-dev libssl-dev procps \
        python3-pip python3-dev python3-setuptools python3-wheel \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \


### PR DESCRIPTION
add procps package to Debian to provide /bin/kill, which is often relied upon by systemd for reloading services (keepalived, for example)

It is debateable if this should be a dependency for said package, but for now it is a quick fix that costs us just 1866 kB

fixes https://github.com/geerlingguy/docker-debian10-ansible/issues/8