### PR TITLE
Revert move to debian:buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:buster
 LABEL maintainer="Jeff Geerling"
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -14,10 +14,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean
-
-# For compatibility, make sure man directory exists.
-# See: https://github.com/geerlingguy/ansible-role-java/issues/64
-RUN mkdir -p /usr/share/man/man1
 
 # Upgrade pip to latest version.
 RUN pip3 install --upgrade pip


### PR DESCRIPTION
As discussed in https://github.com/geerlingguy/docker-debian10-ansible/pull/7 , I am sending this PR to revert the changes