### PR TITLE
Install python3-apt to get rid of apt warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        sudo systemd systemd-sysv \
        build-essential wget libffi-dev libssl-dev \
-       python3-pip python3-dev python3-setuptools python3-wheel \
+       python3-pip python3-dev python3-setuptools python3-wheel python3-apt \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean


### PR DESCRIPTION
Fixes #9.